### PR TITLE
Python 3 supported and prepared for a new Beatbox version on PyPI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+37.0 (Unpublished)
+------------------
+
+* Support for Python 3.4 and 3.5.
+  [hynekcer]
+
+* Update to use version 37.0 of the Salesforce.com partner WSDL by default.
+  [hynekcer]
+
+* Automatic tests for all Python versions by 'tox'.
+  [hynekcer]
+
+* Support for easy sandbox login.
+  [hynekcer]
+
+* Fixed deprecation warning due to deprecated failUnless test method.
+  [hynekcer]
+
 32.1 (2014-12-04)
 -----------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
+include *.rst
 recursive-include examples *.txt *.py
 prune src/beatbox/tests/sfconfig.py

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ Create a sfconfig file in your python path with the following format::
 
     USERNAME='your salesforce username'
     PASSWORD='your salesforce passwordTOKEN'
+    IS_SANDBOX=False  # or True (force.com Sandbox)
 
 where TOKEN is your Salesforce API login token.
 

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,9 @@ First, we need to add some custom fields to the Contacts object in your Salesfor
  * Leave default of 3 lines and field name should default to "Favorite_Fruit"
  * Add a Number labeled "Favorite Integer", with 18 places, 0 decimal places
  * Add a Number labeled "Favorite Float", with 13 places, 5 decimal places
+ * Browse ... Account --> Fields --> Account Site, Account Number.
+   Click "Set Field-Level Security". Select the user profiles for which these
+   fields shoud be visible. (Even the Administrator can not see them by default.)
 
 Create a sfconfig file in your python path with the following format::
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ This module contains 2 versions of the Salesforce.com client:
 Compatibility
 =============
 
-Beatbox supports versions 20.0 through 38.0 of the Salesforce Partner Web
+Beatbox supports versions 20.0 through 60.0 of the Salesforce Partner Web
 Services API. However, the following API calls have not been implemented at
 this time: (but no new method after 32.0)
 

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ This module contains 2 versions of the Salesforce.com client:
 Compatibility
 =============
 
-Beatbox supports versions 16.0 through 32.0 of the Salesforce Partner Web
+Beatbox supports versions 20.0 through 38.0 of the Salesforce Partner Web
 Services API. However, the following API calls have not been implemented at
-this time:
+this time: (but no new method after 32.0)
 
  * emptyRecycleBin
  * executeListView
@@ -36,7 +36,8 @@ this time:
  * sendEmail
  * all describe* calls except describeGlobal, describeSObjects, and describeTabs
 
-Beatbox has been tested with Python 2.7.
+Beatbox has been tested with Python 2.7.9+, 3.4, 3.5. No older versions are
+possible due to the current TLS requirements of Salesforce.
 
 
 Basic Usage Examples
@@ -130,7 +131,8 @@ First, we need to add some custom fields to the Contacts object in your Salesfor
  * Add a Number labeled "Favorite Float", with 13 places, 5 decimal places
  * Browse ... Account --> Fields --> Account Site, Account Number.
    Click "Set Field-Level Security". Select the user profiles for which these
-   fields shoud be visible. (Even the Administrator can not see them by default.)
+   fields should be visible. (Even the Administrator can not see them by default.)
+ * Create a Contact with a nickname "barr" and some Birthdate.
 
 Create a sfconfig file in your python path with the following format::
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -12,39 +12,39 @@ class BeatBoxDemo:
     def login(self, username, password):
         self.password = password
         loginResult = svc.login(username, password)
-        print "sid = " + str(loginResult[sf.sessionId])
-        print "welcome " + str(loginResult[sf.userInfo][sf.userFullName])
+        print("sid = " + str(loginResult[sf.sessionId]))
+        print("welcome " + str(loginResult[sf.userInfo][sf.userFullName]))
 
     def getServerTimestamp(self):
-        print "\ngetServerTimestamp " + svc.getServerTimestamp()
+        print("\ngetServerTimestamp " + svc.getServerTimestamp())
 
     def describeGlobal(self):
-        print "\ndescribeGlobal"
+        print("\ndescribeGlobal")
         dg = svc.describeGlobal()
         for t in dg[sf.types:]:
-            print str(t)
+            print(str(t))
 
     def describeTabs(self):
-        print "\ndescribeTabs"
+        print("\ndescribeTabs")
         dt = svc.describeTabs()
         for t in dt:
-            print str(t[sf.label])
+            print(str(t[sf.label]))
 
     def query(self):
         qr = svc.query("select Id, Name from Account")
-        print "query size = " + str(qr[sf.size])
+        print("query size = " + str(qr[sf.size]))
 
         for rec in qr[sf.records:]:
-            print str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3])
+            print(str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3]))
 
         if (str(qr[sf.done]) == 'false'):
-            print "\nqueryMore"
+            print("\nqueryMore")
             qr = svc.queryMore(str(qr[sf.queryLocator]))
             for rec in qr[sf.records:]:
-                print str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3])
+                print(str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3]))
 
     def upsert(self):
-        print "\nupsert"
+        print("\nupsert")
         t = {
             'type': 'Task',
             'ChandlerId__c': '12345',
@@ -52,7 +52,7 @@ class BeatBoxDemo:
             'ActivityDate': datetime.date(2006, 2, 20)}
 
         ur = svc.upsert('ChandlerId__c', t)
-        print str(ur[sf.success]) + " -> " + str(ur[sf.id])
+        print(str(ur[sf.success]) + " -> " + str(ur[sf.id]))
 
         t = {
             'type': 'Event',
@@ -63,12 +63,12 @@ class BeatBoxDemo:
             'IsPrivate': False}
         ur = svc.upsert('ChandlerId__c', t)
         if str(ur[sf.success]) == 'true':
-            print "id " + str(ur[sf.id])
+            print("id " + str(ur[sf.id]))
         else:
-            print "error " + str(ur[sf.errors][sf.statusCode]) + ":" + str(ur[sf.errors][sf.message])
+            print("error " + str(ur[sf.errors][sf.statusCode]) + ":" + str(ur[sf.errors][sf.message]))
 
     def update(self):
-        print "\nupdate"
+        print("\nupdate")
         a = {
             'type': 'Account',
             'Id':   '00130000005MSO4',
@@ -77,12 +77,12 @@ class BeatBoxDemo:
         sr = svc.update(a)
 
         if str(sr[sf.success]) == 'true':
-            print "id " + str(sr[sf.id])
+            print("id " + str(sr[sf.id]))
         else:
-            print "error " + str(sr[sf.errors][sf.statusCode]) + ":" + str(sr[sf.errors][sf.message])
+            print("error " + str(sr[sf.errors][sf.statusCode]) + ":" + str(sr[sf.errors][sf.message]))
 
     def create(self):
-        print "\ncreate"
+        print("\ncreate")
         a = {
             'type': 'Account',
             'Name': 'New Account',
@@ -91,13 +91,13 @@ class BeatBoxDemo:
         sr = svc.create([a])
 
         if str(sr[sf.success]) == 'true':
-            print "id " + str(sr[sf.id])
+            print("id " + str(sr[sf.id]))
             self.__idToDelete = str(sr[sf.id])
         else:
-            print "error " + str(sr[sf.errors][sf.statusCode]) + ":" + str(sr[sf.errors][sf.message])
+            print("error " + str(sr[sf.errors][sf.statusCode]) + ":" + str(sr[sf.errors][sf.message]))
 
     def getUpdated(self):
-        print "\ngetUpdated"
+        print("\ngetUpdated")
         updatedIds = svc.getUpdated(
             "Account",
             datetime.datetime.today() - datetime.timedelta(1),
@@ -105,77 +105,77 @@ class BeatBoxDemo:
             )
         self.__theIds = []
         for id in updatedIds:
-            print "getUpdated " + str(id)
+            print("getUpdated " + str(id))
             self.__theIds.append(str(id))
 
     def delete(self):
-        print "\ndelete"
+        print("\ndelete")
         dr = svc.delete(self.__idToDelete)
         if str(dr[sf.success]) == 'true':
-            print "deleted id " + str(dr[sf.id])
+            print("deleted id " + str(dr[sf.id]))
         else:
-            print "error " + str(dr[sf.errors][sf.statusCode]) + ":" + str(dr[sf.errors][sf.message])
+            print("error " + str(dr[sf.errors][sf.statusCode]) + ":" + str(dr[sf.errors][sf.message]))
 
     def getDeleted(self):
-        print "\ngetDeleted"
+        print("\ngetDeleted")
         drs = svc.getDeleted(
             "Account",
             datetime.datetime.today() - datetime.timedelta(1),
             datetime.datetime.today() + datetime.timedelta(1)
             )
         for dr in drs:
-            print "getDeleted " + str(dr[sf.id]) + " on " + str(dr[sf.deletedDate])
+            print("getDeleted " + str(dr[sf.id]) + " on " + str(dr[sf.deletedDate]))
 
     def retrieve(self):
-        print "\nretrieve"
+        print("\nretrieve")
         accounts = svc.retrieve("id, name", "Account", self.__theIds)
         for acc in accounts:
             if len(acc._dir) > 0:
-                print str(acc[beatbox._tSObjectNS.Id]) + " : " + str(acc[beatbox._tSObjectNS.Name])
+                print(str(acc[beatbox._tSObjectNS.Id]) + " : " + str(acc[beatbox._tSObjectNS.Name]))
             else:
-                print "<null>"
+                print("<null>")
 
     def getUserInfo(self):
-        print "\ngetUserInfo"
+        print("\ngetUserInfo")
         ui = svc.getUserInfo()
-        print "hello " + str(ui[sf.userFullName]) + " from " + str(ui[sf.organizationName])
+        print("hello " + str(ui[sf.userFullName]) + " from " + str(ui[sf.organizationName]))
 
     def resetPassword(self):
         ui = svc.getUserInfo()
-        print "\nresetPassword"
+        print("\nresetPassword")
         pr = svc.resetPassword(str(ui[sf.userId]))
-        print "password reset to " + str(pr[sf.password])
+        print("password reset to " + str(pr[sf.password]))
 
-        print "\nsetPassword"
+        print("\nsetPassword")
         svc.setPassword(str(ui[sf.userId]), self.password)
-        print "password set back to original password"
+        print("password set back to original password")
 
     def describeSObjects(self):
-        print "\ndescribeSObjects(Account)"
+        print("\ndescribeSObjects(Account)")
         desc = svc.describeSObjects("Account")
         for f in desc[sf.fields:]:
-            print "\t" + str(f[sf.name])
+            print("\t" + str(f[sf.name]))
 
-        print "\ndescribeSObjects(Lead, Contact)"
+        print("\ndescribeSObjects(Lead, Contact)")
         desc = svc.describeSObjects(["Lead", "Contact"])
         for d in desc:
-            print str(d[sf.name]) + "\n" + ("-" * len(str(d[sf.name])))
+            print(str(d[sf.name]) + "\n" + ("-" * len(str(d[sf.name]))))
             for f in d[sf.fields:]:
-                print "\t" + str(f[sf.name])
+                print("\t" + str(f[sf.name]))
 
     def describeLayout(self):
-        print "\ndescribeLayout(Account)"
+        print("\ndescribeLayout(Account)")
         desc = svc.describeLayout("Account")
         for layout in desc[sf.layouts:]:
-            print "sections in detail layout " + str(layout[sf.id])
+            print("sections in detail layout " + str(layout[sf.id]))
             for s in layout[sf.detailLayoutSections:]:
-                print "\t" + str(s[sf.heading])
+                print("\t" + str(s[sf.heading]))
 
 
 if __name__ == "__main__":
 
     if len(sys.argv) != 3:
-        print "usage is demo.py <username> <password>"
+        print("usage is demo.py <username> <password>")
     else:
         demo = BeatBoxDemo()
         demo.login(sys.argv[1], sys.argv[2])

--- a/examples/export.py
+++ b/examples/export.py
@@ -1,5 +1,4 @@
 # runs a sforce SOQL query and saves the results as a csv file.
-
 import sys
 import string
 import beatbox
@@ -19,16 +18,9 @@ def buildSoql(sobjectName):
 
 
 def printColumnHeaders(queryResult):
-    needsComma = 0
     # note that we offset 2 into the records child collection
     # to skip the type and base sObject id elements
-    for col in queryResult[sf.records][2:]:
-        if needsComma:
-            print ',',
-        else:
-            needsComma = 1
-        print col._name[1],
-    print
+    print(', '.join(col._name[1] for col in queryResult[sf.records][2:]))
 
 
 def export(username, password, objectOrSoql):
@@ -45,14 +37,7 @@ def export(username, password, objectOrSoql):
             printColumnHeaders(qr)
             printHeaders = 0
         for row in qr[sf.records:]:
-            needsComma = False
-            for col in row[2:]:
-                if needsComma:
-                    print ',',
-                else:
-                    needsComma = True
-                print str(col),
-            print
+            print(', '.join(str(col) for col in row[2:]))
         if str(qr[sf.done]) == 'true':
             break
         qr = svc.queryMore(str(qr[sf.queryLocator]))
@@ -60,6 +45,6 @@ def export(username, password, objectOrSoql):
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:
-        print "usage is export.py <username> <password> [<sobjectName> || <soqlQuery>]"
+        print("usage is export.py <username> <password> [<sobjectName> || <soqlQuery>]")
     else:
         export(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/examples/soql2atom.py
+++ b/examples/soql2atom.py
@@ -64,7 +64,7 @@ def soql2atom(loginResult, soql, title):
     ent_ns = "urn:sobject.enterprise.soap.sforce.com"
 
     print "content-type: application/atom+xml"
-    doGzip = os.environ.has_key("HTTP_ACCEPT_ENCODING") and "gzip" in string.lower(os.environ["HTTP_ACCEPT_ENCODING"]).split(',')
+    doGzip = "HTTP_ACCEPT_ENCODING" in os.environ and "gzip" in string.lower(os.environ["HTTP_ACCEPT_ENCODING"]).split(',')
     if doGzip:
         print "content-encoding: gzip"
     print ""
@@ -127,17 +127,17 @@ def authenticationRequired(message="Unauthorized"):
     print message
 
 
-if not os.environ.has_key('X_HTTP_AUTHORIZATION') or os.environ['X_HTTP_AUTHORIZATION'] == '':
+if 'X_HTTP_AUTHORIZATION' not in os.environ or os.environ['X_HTTP_AUTHORIZATION'] == '':
     authenticationRequired()
 else:
     auth = os.environ['X_HTTP_AUTHORIZATION']
     (username, password) = base64.decodestring(auth.split(" ")[1]).split(':')
     form = cgi.FieldStorage()
-    if not form.has_key('soql'):
+    if 'soql' not in form:
         raise Exception("Must provide the SOQL query to run via the soql queryString parameter")
     soql = form.getvalue("soql")
     title = "SOQL2ATOM : " + soql
-    if form.has_key("title"):
+    if "title" in form:
         title = form.getvalue("title")
     try:
         lr = svc.login(username, password)

--- a/examples/soql2atom.py
+++ b/examples/soql2atom.py
@@ -63,11 +63,11 @@ def soql2atom(loginResult, soql, title):
     atom_ns = "http://www.w3.org/2005/Atom"
     ent_ns = "urn:sobject.enterprise.soap.sforce.com"
 
-    print "content-type: application/atom+xml"
+    print("content-type: application/atom+xml")
     doGzip = "HTTP_ACCEPT_ENCODING" in os.environ and "gzip" in string.lower(os.environ["HTTP_ACCEPT_ENCODING"]).split(',')
     if doGzip:
-        print "content-encoding: gzip"
-    print ""
+        print("content-encoding: gzip")
+    print()
     x = beatbox.XmlWriter(doGzip)
     x.startPrefixMapping("a", atom_ns)
     x.startPrefixMapping("s", ent_ns)
@@ -108,7 +108,7 @@ def soql2atom(loginResult, soql, title):
         x.characters("\n")
         x.endElement()  # entry
     x.endElement()  # feed
-    print x.endDocument()
+    print(x.endDocument())
 
 
 def writeLink(x, namespace, localname, rel, type, href):
@@ -120,11 +120,11 @@ def writeLink(x, namespace, localname, rel, type, href):
 
 
 def authenticationRequired(message="Unauthorized"):
-    print "status: 401 Unauthorized"
-    print "WWW-authenticate: Basic realm=""www.salesforce.com"""
-    print "content-type: text/plain"
-    print ""
-    print message
+    print("status: 401 Unauthorized")
+    print("WWW-authenticate: Basic realm=""www.salesforce.com""")
+    print("content-type: text/plain")
+    print("")
+    print(message)
 
 
 if 'X_HTTP_AUTHORIZATION' not in os.environ or os.environ['X_HTTP_AUTHORIZATION'] == '':
@@ -142,7 +142,7 @@ else:
     try:
         lr = svc.login(username, password)
         soql2atom(lr, soql, title)
-    except beatbox.SoapFaultError, sfe:
+    except beatbox.SoapFaultError as sfe:
         if (sfe.faultCode == 'INVALID_LOGIN'):
             authenticationRequired(sfe.faultString)
         else:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,5 +2,6 @@
 PYTHON=python
 export PYTHONPATH=.:./src
 
-$PYTHON src/beatbox/tests/test_beatbox.py
+# if the first test fails then the whole script must fail 
+$PYTHON src/beatbox/tests/test_beatbox.py &&
 $PYTHON src/beatbox/tests/test_pythonClient.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='beatbox',
-    version='32.1',  # be sure to update the version in _beatbox.py too
+    version='37.0',  # be sure to update the version in _beatbox.py too
     package_dir={'': 'src'},
     packages=['beatbox'],
     author="Simon Fell et al",
@@ -12,5 +12,12 @@ setup(
     license="GNU GENERAL PUBLIC LICENSE Version 2",
     keywords="python salesforce salesforce.com",
     url="http://code.google.com/p/salesforce-beatbox/",
-    classifiers=["Development Status :: 5 - Production/Stable"]
-    )
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ]
+)

--- a/src/beatbox/__init__.py
+++ b/src/beatbox/__init__.py
@@ -1,7 +1,7 @@
-from _beatbox import _tPartnerNS, _tSObjectNS, _tSoapNS, SoapFaultError, SessionTimeoutError
-from _beatbox import DEFAULT_SERVER_URL
-from _beatbox import Client as XMLClient
-from python_client import Client as PythonClient
+from beatbox._beatbox import _tPartnerNS, _tSObjectNS, _tSoapNS, SoapFaultError, SessionTimeoutError
+from beatbox._beatbox import DEFAULT_SERVER_URL
+from beatbox._beatbox import Client as XMLClient
+from beatbox.python_client import Client as PythonClient
 
 __all__ = (
     'XMLClient', '_tPartnerNS', '_tSObjectNS', '_tSoapNS',

--- a/src/beatbox/_beatbox.py
+++ b/src/beatbox/_beatbox.py
@@ -22,7 +22,7 @@ _sobjectNs = "urn:sobject.partner.soap.sforce.com"
 _envNs = "http://schemas.xmlsoap.org/soap/envelope/"
 _noAttrs = AttributesNSImpl({}, {})
 
-DEFAULT_SERVER_URL = 'https://login.salesforce.com/services/Soap/u/37.0'
+DEFAULT_SERVER_URL = 'https://login.salesforce.com/services/Soap/u/60.0'
 
 # global constants for xmltramp namespaces, used to access response data
 _tPartnerNS = xmltramp.Namespace(_partnerNs)

--- a/src/beatbox/_beatbox.py
+++ b/src/beatbox/_beatbox.py
@@ -38,6 +38,7 @@ logger = logging.getLogger('beatbox')
 
 long = type(0x10000000000000000)
 
+
 def makeConnection(scheme, host):
     if forceHttp or scheme.upper() == 'HTTP':
         return http_client.HTTPConnection(host)
@@ -53,7 +54,12 @@ class Client:
 
     def __del__(self):
         if callable(getattr(self.__conn, 'close', None)):
-            self.__conn.close()
+            try:
+                self.__conn.close()
+            except AttributeError as exc:
+                # run too late in Python 3 if the program terminates
+                if not "no attribute '_real_close'" in exc.args[0]:
+                    raise
 
     # login, the serverUrl and sessionId are automatically handled,
     # returns the loginResult structure

--- a/src/beatbox/_beatbox.py
+++ b/src/beatbox/_beatbox.py
@@ -58,7 +58,9 @@ class Client:
 
     # login, the serverUrl and sessionId are automatically handled,
     # returns the loginResult structure
-    def login(self, username, password):
+    def login(self, username, password, is_sandbox=False):
+        if is_sandbox:
+            self.serverUrl = self.serverUrl.replace('login.', 'test.')
         lr = LoginRequest(self.serverUrl, username, password).post()
         self.useSession(str(lr[_tPartnerNS.sessionId]), str(lr[_tPartnerNS.serverUrl]))
         return lr

--- a/src/beatbox/_beatbox.py
+++ b/src/beatbox/_beatbox.py
@@ -1,6 +1,6 @@
 """beatbox: Makes the salesforce.com SOAP API easily accessible."""
 
-__version__ = '32.1'
+__version__ = '37.0'
 __author__ = "Simon Fell et al"
 __credits__ = "Mad shouts to the sforce possie"
 __copyright__ = "(C) 2006 Simon Fell. GNU GPL 2."
@@ -22,7 +22,7 @@ _sobjectNs = "urn:sobject.partner.soap.sforce.com"
 _envNs = "http://schemas.xmlsoap.org/soap/envelope/"
 _noAttrs = AttributesNSImpl({}, {})
 
-DEFAULT_SERVER_URL = 'https://login.salesforce.com/services/Soap/u/32.0'
+DEFAULT_SERVER_URL = 'https://login.salesforce.com/services/Soap/u/37.0'
 
 # global constants for xmltramp namespaces, used to access response data
 _tPartnerNS = xmltramp.Namespace(_partnerNs)
@@ -58,7 +58,7 @@ class Client:
                 self.__conn.close()
             except AttributeError as exc:
                 # run too late in Python 3 if the program terminates
-                if not "no attribute '_real_close'" in exc.args[0]:
+                if "no attribute '_real_close'" not in exc.args[0]:
                     raise
 
     # login, the serverUrl and sessionId are automatically handled,

--- a/src/beatbox/marshall.py
+++ b/src/beatbox/marshall.py
@@ -1,8 +1,7 @@
-from _beatbox import _tSObjectNS
-from types import ListType, TupleType
+from beatbox._beatbox import _tSObjectNS
 import datetime
-import python_client
 import re
+from beatbox.six import PY2, text_type
 
 
 dateregx = re.compile(r'(\d{4})-(\d{2})-(\d{2})')
@@ -22,6 +21,9 @@ doubletypes = ('double', 'currency', 'percent')
 multitypes = ('combobox', 'multipicklist')
 
 
+def _bool(val):
+    return str(val) == 'true'
+
 _marshallers = dict()
 
 
@@ -31,7 +33,7 @@ def marshall(fieldtype, fieldname, xml, ns=_tSObjectNS):
 
 
 def register(fieldtypes, func):
-    if type(fieldtypes) not in (ListType, TupleType):
+    if type(fieldtypes) not in (list, tuple):
         fieldtypes = [fieldtypes]
     for t in fieldtypes:
         _marshallers[t] = func
@@ -47,8 +49,10 @@ def textMarshaller(fieldname, xml, ns):
     node = xml[getattr(ns, fieldname)]
     text = ''
     for x in node._dir:
-        text += unicode(x)
-    return text.encode('utf-8')
+        text += text_type(x)
+    if PY2:
+        text = text.encode('utf-8')
+    return text
 register(texttypes, textMarshaller)
 
 
@@ -61,7 +65,7 @@ register(multitypes, multiMarshaller)
 
 
 def booleanMarshaller(fieldname, xml, ns):
-    return python_client._bool(xml[getattr(ns, fieldname)])
+    return _bool(xml[getattr(ns, fieldname)])
 register('boolean', booleanMarshaller)
 
 

--- a/src/beatbox/python_client.py
+++ b/src/beatbox/python_client.py
@@ -72,8 +72,8 @@ class Client(BaseClient):
         self.cacheTypeDescriptions = cacheTypeDescriptions
         self.typeDescs = {}
 
-    def login(self, username, passwd):
-        res = BaseClient.login(self, username, passwd)
+    def login(self, username, passwd, is_sandbox=False):
+        res = BaseClient.login(self, username, passwd, is_sandbox)
         data = dict()
         data['passwordExpired'] = _bool(res[_tPartnerNS.passwordExpired])
         data['serverUrl'] = str(res[_tPartnerNS.serverUrl])

--- a/src/beatbox/python_client.py
+++ b/src/beatbox/python_client.py
@@ -40,11 +40,11 @@ class QueryRecordSet(list):
         return self
 
     def __getitem__(self, n):
-        if type(n) == type(''):
+        if isinstance(n, str):
             try:
                 return getattr(self, n)
             except AttributeError:
-                raise KeyError("Not found %r" %n)
+                raise KeyError("Not found %r" % n)
         else:
             return list.__getitem__(self, n)
 
@@ -282,7 +282,7 @@ class Client(BaseClient):
 
         res = BaseClient.query(self, queryString)
         # calculate the union of the sets of record types from each record
-        types = reduce(lambda a, b: a|b, [getRecordTypes(r) for r in res[_tPartnerNS.records:]], set())
+        types = reduce(lambda a, b: a | b, [getRecordTypes(r) for r in res[_tPartnerNS.records:]], set())
         if not self.cacheTypeDescriptions:
             self.flushTypeDescriptionsCache()
         new_types = types - set(self.typeDescs.keys())

--- a/src/beatbox/python_client.py
+++ b/src/beatbox/python_client.py
@@ -10,7 +10,7 @@ _tSchemaInstanceNS = Namespace('http://www.w3.org/2001/XMLSchema-instance')
 _tSchemaNS = Namespace('http://www.w3.org/2001/XMLSchema')
 
 DEFAULT_FIELD_TYPE = "string"
-querytyperegx = re.compile('(?:from|FROM) (\S+)')
+querytyperegx = re.compile(r'(?:from|FROM) (\S+)')
 
 
 class QueryRecord(dict):

--- a/src/beatbox/six.py
+++ b/src/beatbox/six.py
@@ -1,0 +1,44 @@
+"""Simplified "six" package for Beatbox and Python >= 2.7 or >= 3.3"""
+# It is in a setarate module because some checkers can report that
+# something is not a valid code in Python 2 or 3 respectively.
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+from io import BytesIO  # NOQA
+if PY3:
+    from builtins import range as xrange
+    from io import StringIO
+    from http import client as http_client
+    from urllib.parse import urlparse
+    from urllib.request import urlopen
+    text_type = str
+else:
+    from __builtin__ import xrange
+    from StringIO import StringIO
+    import httplib as http_client
+    from urlparse import urlparse
+    from urllib2 import urlopen
+    text_type = unicode  # NOQA
+
+__all__ = ('BytesIO', 'StringIO', 'xrange', 'http_client', 'urlparse', 'text_type', 'urlopen')
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass

--- a/src/beatbox/tests/test_beatbox.py
+++ b/src/beatbox/tests/test_beatbox.py
@@ -10,7 +10,8 @@ svc = beatbox.XMLClient()
 class TestBeatbox(unittest.TestCase):
 
     def setUp(self):
-        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD)
+        is_sandbox = getattr(sfconfig, 'IS_SANDBOX', False)
+        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD, is_sandbox)
         self._todelete = list()
 
     def tearDown(self):

--- a/src/beatbox/tests/test_beatbox.py
+++ b/src/beatbox/tests/test_beatbox.py
@@ -2,6 +2,8 @@ import beatbox
 import datetime
 import sfconfig
 import unittest
+import warnings
+from beatbox.six import PY3
 
 partnerns = beatbox._tPartnerNS
 svc = beatbox.XMLClient()
@@ -11,6 +13,8 @@ class TestBeatbox(unittest.TestCase):
 
     def setUp(self):
         is_sandbox = getattr(sfconfig, 'IS_SANDBOX', False)
+        if PY3:
+            warnings.filterwarnings("ignore", message='.*ssl.SSLSocket', category=ResourceWarning, module='beatbox')  # NOQA
         svc.login(sfconfig.USERNAME, sfconfig.PASSWORD, is_sandbox)
         self._todelete = list()
 

--- a/src/beatbox/tests/test_benchmark.py
+++ b/src/beatbox/tests/test_benchmark.py
@@ -66,9 +66,9 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve(

--- a/src/beatbox/tests/test_benchmark.py
+++ b/src/beatbox/tests/test_benchmark.py
@@ -1,10 +1,10 @@
 from time import time
-from types import ListType, TupleType
 import beatbox
 import datetime
 import gc
 import sfconfig
 import unittest
+from beatbox.six import xrange
 
 BENCHMARK_REPS = 1
 
@@ -19,7 +19,7 @@ def benchmark(func):
         t1 = time()
         gc.enable()
         elapsed = t1 - t0
-        print "\n%s: %s\n" % (func.__name__, elapsed)
+        print("\n%s: %s\n" % (func.__name__, elapsed))
     return benchmarked_func
 
 
@@ -49,7 +49,7 @@ class TestUtils(unittest.TestCase):
         globalres = svc.describeGlobal()
         types = globalres['types']
         res = svc.describeSObjects(types[0])
-        self.assertEqual(type(res), ListType)
+        self.assertEqual(type(res), list)
         self.assertEqual(len(res), 1)
         res = svc.describeSObjects(types[:100])
         self.assertEqual(len(types[:100]), len(res))
@@ -66,7 +66,7 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']

--- a/src/beatbox/tests/test_benchmark.py
+++ b/src/beatbox/tests/test_benchmark.py
@@ -28,7 +28,8 @@ class TestUtils(unittest.TestCase):
     def setUp(self):
         from beatbox._beatbox import DEFAULT_SERVER_URL
         self.svc = svc = beatbox.PythonClient(serverUrl=DEFAULT_SERVER_URL)
-        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD)
+        is_sandbox = getattr(sfconfig, 'IS_SANDBOX', False)
+        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD, is_sandbox)
         self._todelete = list()
 
     def tearDown(self):

--- a/src/beatbox/tests/test_pythonClient.py
+++ b/src/beatbox/tests/test_pythonClient.py
@@ -11,7 +11,8 @@ class TestUtils(unittest.TestCase):
 
     def setUp(self):
         self.svc = svc = beatbox.PythonClient()
-        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD)
+        is_sandbox = getattr(sfconfig, 'IS_SANDBOX', False)
+        svc.login(sfconfig.USERNAME, sfconfig.PASSWORD, is_sandbox)
         self._todelete = list()
 
     def tearDown(self):

--- a/src/beatbox/tests/test_pythonClient.py
+++ b/src/beatbox/tests/test_pythonClient.py
@@ -1,6 +1,6 @@
 from beatbox import SoapFaultError
 from beatbox.python_client import _prepareSObjects
-from types import DictType, StringTypes, IntType, ListType, TupleType
+from beatbox.six import text_type
 import beatbox
 import datetime
 import sfconfig
@@ -28,10 +28,10 @@ class TestUtils(unittest.TestCase):
     def testDescribeGlobal(self):
         svc = self.svc
         res = svc.describeGlobal()
-        self.assertEqual(type(res), DictType)
-        self.failUnless(type(res['encoding']) in StringTypes)
-        self.assertEqual(type(res['maxBatchSize']), IntType)
-        self.assertEqual(type(res['types']), ListType)
+        self.assertEqual(type(res), dict)
+        self.failUnless(type(res['encoding']) in (str, text_type))
+        self.assertEqual(type(res['maxBatchSize']), int)
+        self.assertEqual(type(res['types']), list)
         self.failUnless(len(res['sobjects']) > 0)
         # BBB for API < 17.0
         self.failUnless(len(res['types']) > 0)
@@ -41,7 +41,7 @@ class TestUtils(unittest.TestCase):
         globalres = svc.describeGlobal()
         types = globalres['types'][:100]
         res = svc.describeSObjects(types[0])
-        self.assertEqual(type(res), ListType)
+        self.assertEqual(type(res), list)
         self.assertEqual(len(res), 1)
         res = svc.describeSObjects(types)
         self.assertEqual(len(types), len(res))
@@ -57,7 +57,7 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']
@@ -83,7 +83,7 @@ class TestUtils(unittest.TestCase):
             Favorite_Integer__c=-25
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']
@@ -104,7 +104,7 @@ class TestUtils(unittest.TestCase):
             Favorite_Float__c=-1.999888777
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']
@@ -127,7 +127,7 @@ class TestUtils(unittest.TestCase):
             Favorite_Fruit__c=["Apple", "Orange", "Pear"]
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']
@@ -840,7 +840,7 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.upsert('Email', [data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']
@@ -872,7 +872,7 @@ class TestUtils(unittest.TestCase):
             Description="This is a\nmultiline description.",
             )
         res = self.svc.create([data])
-        self.failUnless(type(res) in (ListType, TupleType))
+        self.failUnless(type(res) in (list, tuple))
         self.failUnless(len(res) == 1)
         self.failUnless(res[0]['success'])
         id = res[0]['id']

--- a/src/beatbox/tests/test_pythonClient.py
+++ b/src/beatbox/tests/test_pythonClient.py
@@ -686,7 +686,7 @@ class TestUtils(unittest.TestCase):
 
     def testSearch(self):
         res = self.svc.search("FIND {barr} in ALL FIELDS RETURNING Contact(Id, Birthdate)")
-        self.assertEqual(len(res), 1)
+        self.assertEqual(len(res), 1, "Not found 'barr' in any field in Contact")
         self.assertEqual(res[0].type, 'Contact')
         self.assertEqual(type(res[0].Birthdate), datetime.date)
 

--- a/src/beatbox/tests/test_pythonClient.py
+++ b/src/beatbox/tests/test_pythonClient.py
@@ -29,12 +29,12 @@ class TestUtils(unittest.TestCase):
         svc = self.svc
         res = svc.describeGlobal()
         self.assertEqual(type(res), dict)
-        self.failUnless(type(res['encoding']) in (str, text_type))
+        self.assertTrue(type(res['encoding']) in (str, text_type))
         self.assertEqual(type(res['maxBatchSize']), int)
         self.assertEqual(type(res['types']), list)
-        self.failUnless(len(res['sobjects']) > 0)
+        self.assertTrue(len(res['sobjects']) > 0)
         # BBB for API < 17.0
-        self.failUnless(len(res['types']) > 0)
+        self.assertTrue(len(res['types']) > 0)
 
     def testDescribeSObjects(self):
         svc = self.svc
@@ -57,9 +57,9 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve(
@@ -83,9 +83,9 @@ class TestUtils(unittest.TestCase):
             Favorite_Integer__c=-25
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve('LastName, FirstName, Favorite_Integer__c', 'Contact', [id])
@@ -104,9 +104,9 @@ class TestUtils(unittest.TestCase):
             Favorite_Float__c=-1.999888777
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve('LastName, FirstName, Favorite_Float__c', 'Contact', [id])
@@ -127,9 +127,9 @@ class TestUtils(unittest.TestCase):
             Favorite_Fruit__c=["Apple", "Orange", "Pear"]
             )
         res = svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve('LastName, FirstName, Phone, Email, Birthdate, \
@@ -207,7 +207,7 @@ class TestUtils(unittest.TestCase):
         res = svc.create([data])
         id = res[0]['id']
         res = svc.delete([id])
-        self.failUnless(res[0]['success'])
+        self.assertTrue(res[0]['success'])
         contacts = svc.retrieve('LastName', 'Contact', [id])
         self.assertEqual(len(contacts), 0)
 
@@ -314,8 +314,8 @@ class TestUtils(unittest.TestCase):
             Id=id,
             Birthdate=newdate)
         res = svc.update(data)
-        self.failUnless(not res[0]['success'])
-        self.failUnless(len(res[0]['errors']) > 0)
+        self.assertTrue(not res[0]['success'])
+        self.assertTrue(len(res[0]['errors']) > 0)
 
     def testQuery(self):
         svc = self.svc
@@ -378,7 +378,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(res['size'], 2)
         # conditional expression as *empty* positional arg
         res = svc.query('LastName', 'Contact', '')
-        self.failUnless(res['size'] > 0)
+        self.assertTrue(res['size'] > 0)
         # conditional expression as kwarg
         res = svc.query(
             'Id, LastName, FirstName, Phone, Email, Birthdate',
@@ -645,7 +645,7 @@ class TestUtils(unittest.TestCase):
 
         res = svc.query("SELECT MAX(CreatedDate) FROM Contact GROUP BY LastName")
         # the aggregate result is in the 'expr0' attribute of the result
-        self.failUnless(hasattr(res[0], 'expr0'))
+        self.assertTrue(hasattr(res[0], 'expr0'))
         # (unfortunately no field type info is returned as part of the
         # AggregateResult object, so we can't automatically marshall to the
         # correct Python type)
@@ -678,10 +678,10 @@ class TestUtils(unittest.TestCase):
         res = svc.query(
             'LastName, FirstName, Phone, Email, Birthdate',
             'Contact', "LastName = 'Doe'")
-        self.failUnless(not res['done'])
+        self.assertTrue(not res['done'])
         self.assertEqual(len(res['records']), 200)
         res = svc.queryMore(res['queryLocator'])
-        self.failUnless(res['done'])
+        self.assertTrue(res['done'])
         self.assertEqual(len(res['records']), 50)
 
     def testSearch(self):
@@ -709,9 +709,9 @@ class TestUtils(unittest.TestCase):
         id = res[0]['id']
         svc.delete(id)
         res = svc.getDeleted('Contact', startdate, enddate)
-        self.failUnless(len(res) != 0)
+        self.assertTrue(len(res) != 0)
         ids = [r['id'] for r in res]
-        self.failUnless(id in ids)
+        self.assertTrue(id in ids)
 
     def testGetUpdated(self):
         svc = self.svc
@@ -734,37 +734,37 @@ class TestUtils(unittest.TestCase):
             FirstName='Jane')
         svc.update(data)
         res = svc.getUpdated('Contact', startdate, enddate)
-        self.failUnless(id in res)
+        self.assertTrue(id in res)
 
     def testGetUserInfo(self):
         svc = self.svc
         userinfo = svc.getUserInfo()
-        self.failUnless('accessibilityMode' in userinfo)
-        self.failUnless('currencySymbol' in userinfo)
-        self.failUnless('organizationId' in userinfo)
-        self.failUnless('organizationMultiCurrency' in userinfo)
-        self.failUnless('organizationName' in userinfo)
-        self.failUnless('userDefaultCurrencyIsoCode' in userinfo)
-        self.failUnless('userEmail' in userinfo)
-        self.failUnless('userFullName' in userinfo)
-        self.failUnless('userId' in userinfo)
-        self.failUnless('userLanguage' in userinfo)
-        self.failUnless('userLocale' in userinfo)
-        self.failUnless('userTimeZone' in userinfo)
-        self.failUnless('userUiSkin' in userinfo)
+        self.assertTrue('accessibilityMode' in userinfo)
+        self.assertTrue('currencySymbol' in userinfo)
+        self.assertTrue('organizationId' in userinfo)
+        self.assertTrue('organizationMultiCurrency' in userinfo)
+        self.assertTrue('organizationName' in userinfo)
+        self.assertTrue('userDefaultCurrencyIsoCode' in userinfo)
+        self.assertTrue('userEmail' in userinfo)
+        self.assertTrue('userFullName' in userinfo)
+        self.assertTrue('userId' in userinfo)
+        self.assertTrue('userLanguage' in userinfo)
+        self.assertTrue('userLocale' in userinfo)
+        self.assertTrue('userTimeZone' in userinfo)
+        self.assertTrue('userUiSkin' in userinfo)
 
     def testDescribeTabs(self):
         tabinfo = self.svc.describeTabs()
         for info in tabinfo:
-            self.failUnless('label' in info)
-            self.failUnless('logoUrl' in info)
-            self.failUnless('selected' in info)
-            self.failUnless('tabs' in info)
+            self.assertTrue('label' in info)
+            self.assertTrue('logoUrl' in info)
+            self.assertTrue('selected' in info)
+            self.assertTrue('tabs' in info)
             for tab in info['tabs']:
-                self.failUnless('custom' in tab)
-                self.failUnless('label' in tab)
-                self.failUnless('sObjectName' in tab)
-                self.failUnless('url' in tab)
+                self.assertTrue('custom' in tab)
+                self.assertTrue('label' in tab)
+                self.assertTrue('sObjectName' in tab)
+                self.assertTrue('url' in tab)
 
     def testDescribeLayout(self):
         svc = self.svc
@@ -793,7 +793,7 @@ class TestUtils(unittest.TestCase):
             Favorite_Fruit__c=newList)
         svc.update(data)
         contacts = svc.retrieve('LastName, Favorite_Fruit__c', 'Contact', [id])
-        self.failUnless(isinstance(contacts[0]['Favorite_Fruit__c'], list))
+        self.assertTrue(isinstance(contacts[0]['Favorite_Fruit__c'], list))
         self.assertEqual(len(contacts[0]['Favorite_Fruit__c']), 0)
 
     def testAddToEmptyMultiPicklist(self):
@@ -811,7 +811,7 @@ class TestUtils(unittest.TestCase):
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve('LastName, Favorite_Fruit__c', 'Contact', [id])
-        self.failUnless(isinstance(contacts[0]['Favorite_Fruit__c'], list))
+        self.assertTrue(isinstance(contacts[0]['Favorite_Fruit__c'], list))
         self.assertEqual(len(contacts[0]['Favorite_Fruit__c']), 0)
         data = dict(
             type='Contact',
@@ -819,7 +819,7 @@ class TestUtils(unittest.TestCase):
             Favorite_Fruit__c=newList)
         svc.update(data)
         contacts = svc.retrieve('LastName, Favorite_Fruit__c', 'Contact', [id])
-        self.failUnless(isinstance(contacts[0]['Favorite_Fruit__c'], list))
+        self.assertTrue(isinstance(contacts[0]['Favorite_Fruit__c'], list))
         self.assertEqual(len(contacts[0]['Favorite_Fruit__c']), 2)
 
     def testIsNillableField(self):
@@ -840,9 +840,9 @@ class TestUtils(unittest.TestCase):
             Birthdate=datetime.date(1970, 1, 4)
             )
         res = svc.upsert('Email', [data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = svc.retrieve(
@@ -872,9 +872,9 @@ class TestUtils(unittest.TestCase):
             Description="This is a\nmultiline description.",
             )
         res = self.svc.create([data])
-        self.failUnless(type(res) in (list, tuple))
-        self.failUnless(len(res) == 1)
-        self.failUnless(res[0]['success'])
+        self.assertTrue(type(res) in (list, tuple))
+        self.assertTrue(len(res) == 1)
+        self.assertTrue(res[0]['success'])
         id = res[0]['id']
         self._todelete.append(id)
         contacts = self.svc.retrieve('Description', 'Contact', [id])

--- a/src/beatbox/xmltramp.py
+++ b/src/beatbox/xmltramp.py
@@ -234,7 +234,7 @@ class Element:
         if len(_pos) > 1:
             for i in range(0, len(_pos), 2):
                 self._attrs[_pos[i]] = _pos[i+1]
-        if len(_pos) == 1 is not None:
+        if len(_pos) == 1:
             return self._attrs[_pos[0]]
         if len(_pos) == 0:
             return self._attrs

--- a/src/beatbox/xmltramp.py
+++ b/src/beatbox/xmltramp.py
@@ -217,7 +217,7 @@ class Element:
             if self._dNS and not islst(n):
                 n = (self._dNS, n)
 
-            for i in range(len(self)):
+            for i in reversed(range(len(self))):
                 if self[i]._name == n:
                     del self[i]
         else:

--- a/src/beatbox/xmltramp.py
+++ b/src/beatbox/xmltramp.py
@@ -383,8 +383,24 @@ def unittest():
     </doc>""")
 
     assert repr(d) == '<doc version="2.7182818284590451">...</doc>'
-    assert d.__repr__(1) == '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://example.org/bar" version="2.7182818284590451"><author>John Polk and John Palfrey</author><dc:creator>John Polk</dc:creator><dc:creator>John Palfrey</dc:creator><bbc:show bbc:station="4">Buffy</bbc:show></doc>'
-    assert d.__repr__(1, 1) == '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://example.org/bar" version="2.7182818284590451">\n\t<author>John Polk and John Palfrey</author>\n\t<dc:creator>John Polk</dc:creator>\n\t<dc:creator>John Palfrey</dc:creator>\n\t<bbc:show bbc:station="4">Buffy</bbc:show>\n</doc>'
+    assert d.__repr__(1) == (
+        '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        ' xmlns="http://example.org/bar" version="2.7182818284590451">'
+        '<author>John Polk and John Palfrey</author>'
+        '<dc:creator>John Polk</dc:creator>'
+        '<dc:creator>John Palfrey</dc:creator>'
+        '<bbc:show bbc:station="4">Buffy</bbc:show>'
+        '</doc>'
+    )
+    assert d.__repr__(1, 1) == (
+        '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        ' xmlns="http://example.org/bar" version="2.7182818284590451">\n'
+        '\t<author>John Polk and John Palfrey</author>\n'
+        '\t<dc:creator>John Polk</dc:creator>\n'
+        '\t<dc:creator>John Palfrey</dc:creator>\n'
+        '\t<bbc:show bbc:station="4">Buffy</bbc:show>\n'
+        '</doc>'
+    )
 
     assert repr(parse("<doc xml:lang='en' />")) == '<doc xml:lang="en"></doc>'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py{27,34,35}
+
+[testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+deps =
+    flake8
+    rstcheck
+commands =
+    ./run_tests.sh
+    # lint code style and docs
+    flake8 .
+    rstcheck README.rst CHANGES.rst
+[flake8]
+max-line-length = 137
+ignore = E123,E226,E241,E402,W503
+exclude = .tox,*.egg,build


### PR DESCRIPTION
I prepared a support for Python 3 and automatic tests for all supported Python versions.
Everything is updated for version 37.0 of Salesforce and tested also with 38.0.
If everything would be OK, it is still necessary to change the string "(Unpublished)" to the right date of new release.
- Support for Python 3
- Update to use version 37.0 of the Salesforce.com partner WSDL by default.
- Automatic tests for all Python versions by 'tox'.
- Support for easy sandbox login.
- Fixed deprecation warning due to deprecated failUnless test method.

(Thank you for the previous version.)
